### PR TITLE
Connect the home page view to the DB (for loading updates)

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,5 +1,5 @@
 class Category < ApplicationRecord
 
-  has_many :resources
+  has_many :resources, dependent: :destroy
 
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,5 +1,5 @@
 class Category < ApplicationRecord
 
-  has_many :resources, dependent: :destroy
+  has_many :resources, dependent: :nullify
 
 end

--- a/app/views/pages/_resource-card.html.erb
+++ b/app/views/pages/_resource-card.html.erb
@@ -1,0 +1,16 @@
+<div class="col-md-4 mb-5">
+  <div class="card h-100">
+    <div class="embed-responsive embed-responsive-16by9 card-img-top">
+    <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/<%= resource.video_id %>?t=<%= resource.start_time %>"
+      allowfullscreen></iframe>
+    </div>
+
+    <div class="card-body">
+    <h4 class="card-title"><%= resource.name %></h4>
+    <p class="card-text"><%= sanitize resource.description %></p>
+    </div>
+    <div class="card-footer">
+    <a href="https://youtu.be/<%= resource.video_id %>?t=<%= resource.start_time %>" class="btn btn-primary" target='_blank'>Watch</a>
+    </div>
+  </div>
+</div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -45,24 +45,7 @@
     </div>
 
     <% Category.find_by(slug:'canada').resources.by_date.first(3).each do |resource| %>
-
-      <div class="col-md-4 mb-5">
-        <div class="card h-100">
-          <div class="embed-responsive embed-responsive-16by9 card-img-top">
-            <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/<%= resource.video_id %>?t=<%= resource.start_time %>"
-              allowfullscreen></iframe>
-          </div>
-
-          <div class="card-body">
-            <h4 class="card-title"><%= resource.name %></h4>
-            <p class="card-text"><%= resource.description %></p>
-          </div>
-          <div class="card-footer">
-            <a href="https://youtu.be/<%= resource.video_id %>?t=<%= resource.start_time %>" class="btn btn-primary" target='_blank'>Watch</a>
-          </div>
-        </div>
-      </div>
-
+      <%= render partial: 'resource-card', locals: { resource: resource } %>
     <% end %>
 
     <div class="col-md-12">
@@ -70,66 +53,21 @@
     </div>
 
     <% Category.find_by(slug:'alberta').resources.by_date.first(3).each do |resource| %>
-      <div class="col-md-4 mb-5">
-        <div class="card h-100">
-          <div class="embed-responsive embed-responsive-16by9 card-img-top">
-            <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/<%= resource.video_id %>?t=<%= resource.start_time %>"
-              allowfullscreen></iframe>
-          </div>
-
-          <div class="card-body">
-            <h4 class="card-title"><%= resource.name %></h4>
-            <p class="card-text"><%= sanitize resource.description %></p>
-          </div>
-          <div class="card-footer">
-            <a href="https://youtu.be/<%= resource.video_id %>?t=<%= resource.start_time %>" class="btn btn-primary" target='_blank'>Watch</a>
-          </div>
-        </div>
-      </div>
+      <%= render partial: 'resource-card', locals: { resource: resource } %>
     <% end %>
 
     <div class="col-md-12">
       <h2>British Columbia</h2>
     </div>
     <% Category.find_by(slug:'british-columbia').resources.by_date.first(3).each do |resource| %>
-      <div class="col-md-4 mb-5">
-        <div class="card h-100">
-          <div class="embed-responsive embed-responsive-16by9 card-img-top">
-            <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/<%= resource.video_id %>?t=<%= resource.start_time %>"
-              allowfullscreen></iframe>
-          </div>
-
-          <div class="card-body">
-            <h4 class="card-title"><%= resource.name %></h4>
-            <p class="card-text"><%= sanitize resource.description %></p>
-          </div>
-          <div class="card-footer">
-            <a href="https://youtu.be/<%= resource.video_id %>?t=<%= resource.start_time %>" class="btn btn-primary" target='_blank'>Watch</a>
-          </div>
-        </div>
-      </div>
+      <%= render partial: 'resource-card', locals: { resource: resource } %>
     <% end %>
 
     <div class="col-md-12">
       <h2>Ontario</h2>
     </div>
     <% Category.find_by(slug:'ontario').resources.by_date.first(3).each do |resource| %>
-      <div class="col-md-4 mb-5">
-        <div class="card h-100">
-          <div class="embed-responsive embed-responsive-16by9 card-img-top">
-            <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/<%= resource.video_id %>?t=<%= resource.start_time %>"
-              allowfullscreen></iframe>
-          </div>
-
-          <div class="card-body">
-            <h4 class="card-title"><%= resource.name %></h4>
-            <p class="card-text"><%= sanitize resource.description %></p>
-          </div>
-          <div class="card-footer">
-            <a href="https://youtu.be/<%= resource.video_id %>?t=<%= resource.start_time %>" class="btn btn-primary" target='_blank'>Watch</a>
-          </div>
-        </div>
-      </div>
+      <%= render partial: 'resource-card', locals: { resource: resource } %>
     <% end %>
 
   </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -39,37 +39,15 @@
 <div class="container">
 
   <div class="row">
+    <% Category.where(kind: 'daily_update').order(:priority).each do |category| %>
+      <div class="col-md-12">
+        <h2><%= category.name %></h2>
+      </div>
 
-    <div class="col-md-12">
-      <h2>Canada</h2>
-    </div>
-
-    <% Category.find_by(slug:'canada').resources.by_date.first(3).each do |resource| %>
-      <%= render partial: 'resource-card', locals: { resource: resource } %>
+      <% category.resources.by_date.first(3).each do |resource| %>
+        <%= render partial: 'resource-card', locals: { resource: resource } %>
+      <% end %>
     <% end %>
-
-    <div class="col-md-12">
-      <h2>Alberta</h2>
-    </div>
-
-    <% Category.find_by(slug:'alberta').resources.by_date.first(3).each do |resource| %>
-      <%= render partial: 'resource-card', locals: { resource: resource } %>
-    <% end %>
-
-    <div class="col-md-12">
-      <h2>British Columbia</h2>
-    </div>
-    <% Category.find_by(slug:'british-columbia').resources.by_date.first(3).each do |resource| %>
-      <%= render partial: 'resource-card', locals: { resource: resource } %>
-    <% end %>
-
-    <div class="col-md-12">
-      <h2>Ontario</h2>
-    </div>
-    <% Category.find_by(slug:'ontario').resources.by_date.first(3).each do |resource| %>
-      <%= render partial: 'resource-card', locals: { resource: resource } %>
-    <% end %>
-
   </div>
   <!-- /.row -->
 

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -69,284 +69,68 @@
       <h2>Alberta</h2>
     </div>
 
-    <div class="col-md-4 mb-5">
-      <div class="card h-100">
-        <div class="embed-responsive embed-responsive-16by9 card-img-top">
-          <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/5eNZMiFX9Pc"
-            allowfullscreen></iframe>
-        </div>
+    <% Category.find_by(slug:'alberta').resources.by_date.first(3).each do |resource| %>
+      <div class="col-md-4 mb-5">
+        <div class="card h-100">
+          <div class="embed-responsive embed-responsive-16by9 card-img-top">
+            <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/<%= resource.video_id %>?t=<%= resource.start_time %>"
+              allowfullscreen></iframe>
+          </div>
 
-        <div class="card-body">
-          <h4 class="card-title">March 23, 2020</h4>
-          <p class="card-text">
-            <strong>Total Cases:</strong> 301 <br>
-            <strong>New Cases:</strong> 42 <br>
-          </p>
-        </div>
-        <div class="card-footer">
-          <a href="https://youtu.be/5eNZMiFX9Pc" class="btn btn-primary" target='_blank'>Watch</a>
+          <div class="card-body">
+            <h4 class="card-title"><%= resource.name %></h4>
+            <p class="card-text"><%= sanitize resource.description %></p>
+          </div>
+          <div class="card-footer">
+            <a href="https://youtu.be/<%= resource.video_id %>?t=<%= resource.start_time %>" class="btn btn-primary" target='_blank'>Watch</a>
+          </div>
         </div>
       </div>
-    </div>
-
-    <div class="col-md-4 mb-5">
-      <div class="card h-100">
-        <div class="embed-responsive embed-responsive-16by9 card-img-top">
-          <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/sV5QnlvFfXY"
-            allowfullscreen></iframe>
-        </div>
-
-        <div class="card-body">
-          <h4 class="card-title">March 21, 2020</h4>
-          <p class="card-text">
-            <strong>Total Cases:</strong> 226 <br>
-            <strong>New Cases:</strong> 31 <br>
-          </p>
-        </div>
-        <div class="card-footer">
-          <a href="https://youtu.be/sV5QnlvFfXY" class="btn btn-primary" target='_blank'>Watch</a>
-        </div>
-      </div>
-    </div>
-
-    <div class="col-md-4 mb-5">
-      <div class="card h-100">
-        <div class="embed-responsive embed-responsive-16by9 card-img-top">
-          <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/s6SkgYaQkOc"
-            allowfullscreen></iframe>
-        </div>
-
-        <div class="card-body">
-          <h4 class="card-title">March 20, 2020</h4>
-          <p class="card-text">
-            <strong>Total Cases:</strong> 195 <br>
-            <strong>New Cases:</strong> 49 <br>
-          </p>
-        </div>
-        <div class="card-footer">
-          <a href="https://youtu.be/s6SkgYaQkOc" class="btn btn-primary" target='_blank'>Watch</a>
-        </div>
-      </div>
-    </div>
-
-
-    <% if false %>
-    <!-- OLD -->
-    <div class="col-md-4 mb-5">
-      <div class="card h-100">
-        <div class="embed-responsive embed-responsive-16by9 card-img-top">
-          <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/alzOXftShR0"
-            allowfullscreen></iframe>
-        </div>
-
-        <div class="card-body">
-          <h4 class="card-title">March 19, 2020</h4>
-          <p class="card-text">
-            <strong>Total Cases:</strong> 146 <br>
-            <strong>New Cases:</strong> 27 <br>
-          </p>
-        </div>
-        <div class="card-footer">
-          <a href="https://youtu.be/alzOXftShR0" class="btn btn-primary" target='_blank'>Watch</a>
-        </div>
-      </div>
-    </div>
     <% end %>
 
     <div class="col-md-12">
       <h2>British Columbia</h2>
     </div>
-    <div class="col-md-4 mb-5">
-      <div class="card h-100">
-        <div class="embed-responsive embed-responsive-16by9 card-img-top">
-          <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/tSb19Trz-uQ"
-            allowfullscreen></iframe>
-        </div>
+    <% Category.find_by(slug:'british-columbia').resources.by_date.first(3).each do |resource| %>
+      <div class="col-md-4 mb-5">
+        <div class="card h-100">
+          <div class="embed-responsive embed-responsive-16by9 card-img-top">
+            <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/<%= resource.video_id %>?t=<%= resource.start_time %>"
+              allowfullscreen></iframe>
+          </div>
 
-        <div class="card-body">
-          <h4 class="card-title">March 23, 2020</h4>
-          <p class="card-text">
-            Note: First 15 seconds has no audio<br><br>
-            <strong>Total Cases:</strong> 472 <br>
-            <strong>New Cases (48 hrs):</strong> 48 <br>
-            <strong>Vancouver Coastal Health:</strong> 248 <br>
-            <strong>Fraser Health:</strong> 150 <br>
-            <strong>Vancouver Island:</strong> 39 <br>
-            <strong>Interior Health:</strong> 30 <br>
-            <strong>Northern Health:</strong> 5 <br>
-          </p>
-        </div>
-        <div class="card-footer">
-          <a href="https://youtu.be/tSb19Trz-uQ" class="btn btn-primary" target='_blank'>Watch</a>
+          <div class="card-body">
+            <h4 class="card-title"><%= resource.name %></h4>
+            <p class="card-text"><%= sanitize resource.description %></p>
+          </div>
+          <div class="card-footer">
+            <a href="https://youtu.be/<%= resource.video_id %>?t=<%= resource.start_time %>" class="btn btn-primary" target='_blank'>Watch</a>
+          </div>
         </div>
       </div>
-    </div>
-
-    <div class="col-md-4 mb-5">
-      <div class="card h-100">
-        <div class="embed-responsive embed-responsive-16by9 card-img-top">
-          <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/lJTIFJFFJpw"
-            allowfullscreen></iframe>
-        </div>
-
-        <div class="card-body">
-          <h4 class="card-title">March 21, 2020</h4>
-          <p class="card-text">
-            <strong>Total Cases:</strong> 424 <br>
-            <strong>New Cases:</strong> 74 <br>
-            <strong>Vancouver Coastal Health:</strong> 230 <br>
-            <strong>Fraser Health:</strong> 126 <br>
-            <strong>Vancouver Island:</strong> 37 <br>
-            <strong>Interior Health:</strong> 27 <br>
-            <strong>Northern Health:</strong> 4 <br>
-          </p>
-        </div>
-        <div class="card-footer">
-          <a href="https://youtu.be/lJTIFJFFJpw" class="btn btn-primary" target='_blank'>Watch</a>
-        </div>
-      </div>
-    </div>
-
-    <div class="col-md-4 mb-5">
-      <div class="card h-100">
-        <div class="embed-responsive embed-responsive-16by9 card-img-top">
-          <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/o6eVdtjWq8Y"
-            allowfullscreen></iframe>
-        </div>
-
-        <div class="card-body">
-          <h4 class="card-title">March 20, 2020</h4>
-          <p class="card-text">
-            <strong>Total Cases:</strong> 348 <br>
-            <strong>New Cases:</strong> 77 <br>
-            <strong>Vancouver Coastal Health:</strong> 200 <br>
-            <strong>Fraser Health:</strong> 95 <br>
-            <strong>Vancouver Island:</strong> 30 <br>
-            <strong>Interior Health:</strong> 19 <br>
-            <strong>Northern Health:</strong> 4 <br>
-          </p>
-        </div>
-        <div class="card-footer">
-          <a href="https://youtu.be/o6eVdtjWq8Y" class="btn btn-primary" target='_blank'>Watch</a>
-        </div>
-      </div>
-    </div>
-
-    <% if false %>
-    <!-- OLD -->
-    <div class="col-md-4 mb-5">
-      <div class="card h-100">
-        <div class="embed-responsive embed-responsive-16by9 card-img-top">
-          <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/grnm1mR-6Pk"
-            allowfullscreen></iframe>
-        </div>
-
-        <div class="card-body">
-          <h4 class="card-title">March 19, 2020</h4>
-          <p class="card-text">
-            <strong>Total Cases:</strong> 271 <br>
-            <strong>New Cases:</strong> 40 <br>
-            <strong>Vancouver Coastal Health:</strong> 152 <br>
-            <strong>Fraser Health:</strong> 81 <br>
-            <strong>Vancouver Island:</strong> 22 <br>
-            <strong>Interior Health:</strong> 12 <br>
-            <strong>Northern Health:</strong> 4 <br>
-          </p>
-        </div>
-        <div class="card-footer">
-          <a href="https://youtu.be/grnm1mR-6Pk" class="btn btn-primary" target='_blank'>Watch</a>
-        </div>
-      </div>
-    </div>
     <% end %>
 
     <div class="col-md-12">
       <h2>Ontario</h2>
     </div>
+    <% Category.find_by(slug:'ontario').resources.by_date.first(3).each do |resource| %>
+      <div class="col-md-4 mb-5">
+        <div class="card h-100">
+          <div class="embed-responsive embed-responsive-16by9 card-img-top">
+            <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/<%= resource.video_id %>?t=<%= resource.start_time %>"
+              allowfullscreen></iframe>
+          </div>
 
-    <div class="col-md-4 mb-5">
-      <div class="card h-100">
-        <div class="embed-responsive embed-responsive-16by9 card-img-top">
-          <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/g_fNMmWpdlM?start=2521"
-            allowfullscreen></iframe>
-        </div>
-
-        <div class="card-body">
-          <h4 class="card-title">March 23, 2020</h4>
-          <p class="card-text">
-
-
-          </p>
-        </div>
-        <div class="card-footer">
-          <a href="https://youtu.be/g_fNMmWpdlM?start=2521" class="btn btn-primary" target='_blank'>Watch</a>
+          <div class="card-body">
+            <h4 class="card-title"><%= resource.name %></h4>
+            <p class="card-text"><%= sanitize resource.description %></p>
+          </div>
+          <div class="card-footer">
+            <a href="https://youtu.be/<%= resource.video_id %>?t=<%= resource.start_time %>" class="btn btn-primary" target='_blank'>Watch</a>
+          </div>
         </div>
       </div>
-    </div>
-
-    <div class="col-md-4 mb-5">
-      <div class="card h-100">
-        <div class="embed-responsive embed-responsive-16by9 card-img-top">
-          <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/ARBgnsoRQNY"
-            allowfullscreen></iframe>
-        </div>
-
-        <div class="card-body">
-          <h4 class="card-title">March 21, 2020</h4>
-          <p class="card-text">
-
-
-          </p>
-        </div>
-        <div class="card-footer">
-          <a href="https://youtu.be/ARBgnsoRQNY" class="btn btn-primary" target='_blank'>Watch</a>
-        </div>
-      </div>
-    </div>
-
-    <div class="col-md-4 mb-5">
-      <div class="card h-100">
-        <div class="embed-responsive embed-responsive-16by9 card-img-top">
-          <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/10b5fzKqfdM"
-            allowfullscreen></iframe>
-        </div>
-
-        <div class="card-body">
-          <h4 class="card-title">March 20, 2020</h4>
-          <p class="card-text">
-
-          </p>
-        </div>
-        <div class="card-footer">
-          <a href="https://youtu.be/10b5fzKqfdM" class="btn btn-primary" target='_blank'>Watch</a>
-        </div>
-      </div>
-    </div>
-
-
-    <% if false %>
-    <!-- OLD -->
-    <div class="col-md-4 mb-5">
-      <div class="card h-100">
-        <div class="embed-responsive embed-responsive-16by9 card-img-top">
-          <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/NdHmGP96ow4"
-            allowfullscreen></iframe>
-        </div>
-
-        <div class="card-body">
-          <h4 class="card-title">March 19, 2020</h4>
-          <p class="card-text">
-
-          </p>
-        </div>
-        <div class="card-footer">
-          <a href="https://youtu.be/NdHmGP96ow4" class="btn btn-primary" target='_blank'>Watch</a>
-        </div>
-      </div>
-    </div>
     <% end %>
-
-
 
   </div>
   <!-- /.row -->

--- a/db/migrate/20200324193209_add_daily_update_videos.rb
+++ b/db/migrate/20200324193209_add_daily_update_videos.rb
@@ -1,0 +1,159 @@
+class AddDailyUpdateVideos < ActiveRecord::Migration[6.0]
+  def change
+    ab = Category.find_by(slug: 'alberta')
+    bc = Category.find_by(slug: 'british-columbia')
+    on = Category.find_by(slug: 'ontario')
+
+    resources = Resource.create!([
+      {
+        name: 'March 23, 2020',
+        description: '<strong>Total Cases:</strong> 301 <br>
+        <strong>New Cases:</strong> 42 <br>',
+        video_id: '5eNZMiFX9Pc',
+        start_time: nil,
+        date: DateTime.new(2020, 3, 23, 8, 0, 0, '-07:00'),
+        category: ab,
+        kind: 'youtube_video'
+      },
+      {
+        name: 'March 21, 2020',
+        description: '<strong>Total Cases:</strong> 226 <br>
+        <strong>New Cases:</strong> 31 <br>',
+        video_id: 'sV5QnlvFfXY',
+        start_time: nil,
+        date: DateTime.new(2020, 3, 21, 8, 0, 0, '-07:00'),
+        category: ab,
+        kind: 'youtube_video'
+      },
+      {
+        name: 'March 20, 2020',
+        description: '<strong>Total Cases:</strong> 195 <br>
+        <strong>New Cases:</strong> 49 <br>',
+        video_id: 's6SkgYaQkOc',
+        start_time: nil,
+        date: DateTime.new(2020, 3, 20, 8, 0, 0, '-07:00'),
+        category: ab,
+        kind: 'youtube_video'
+      },
+      {
+        name: 'March 19, 2020',
+        description: '<strong>Total Cases:</strong> 146 <br>
+        <strong>New Cases:</strong> 27 <br>',
+        video_id: 'alzOXftShR0',
+        start_time: nil,
+        date: DateTime.new(2020, 3, 19, 8, 0, 0, '-07:00'),
+        category: ab,
+        kind: 'youtube_video'
+      },
+      {
+        name: 'March 23, 2020',
+        description: '
+        Note: First 15 seconds has no audio<br><br>
+        <strong>Total Cases:</strong> 472 <br>
+        <strong>New Cases (48 hrs):</strong> 48 <br>
+        <strong>Vancouver Coastal Health:</strong> 248 <br>
+        <strong>Fraser Health:</strong> 150 <br>
+        <strong>Vancouver Island:</strong> 39 <br>
+        <strong>Interior Health:</strong> 30 <br>
+        <strong>Northern Health:</strong> 5 <br>
+        ',
+        video_id: 'tSb19Trz-uQ',
+        start_time: nil,
+        date: DateTime.new(2020, 3, 23, 8, 0, 0, '-07:00'),
+        category: bc,
+        kind: 'youtube_video'
+      },
+      {
+        name: 'March 21, 2020',
+        description: '
+        <strong>Total Cases:</strong> 424 <br>
+        <strong>New Cases:</strong> 74 <br>
+        <strong>Vancouver Coastal Health:</strong> 230 <br>
+        <strong>Fraser Health:</strong> 126 <br>
+        <strong>Vancouver Island:</strong> 37 <br>
+        <strong>Interior Health:</strong> 27 <br>
+        <strong>Northern Health:</strong> 4 <br>
+        ',
+        video_id: 'lJTIFJFFJpw',
+        start_time: nil,
+        date: DateTime.new(2020, 3, 21, 8, 0, 0, '-07:00'),
+        category: bc,
+        kind: 'youtube_video'
+      },
+      {
+        name: 'March 20, 2020',
+        description: '
+        <strong>Total Cases:</strong> 348 <br>
+        <strong>New Cases:</strong> 77 <br>
+        <strong>Vancouver Coastal Health:</strong> 200 <br>
+        <strong>Fraser Health:</strong> 95 <br>
+        <strong>Vancouver Island:</strong> 30 <br>
+        <strong>Interior Health:</strong> 19 <br>
+        <strong>Northern Health:</strong> 4 <br>
+        ',
+        video_id: 'o6eVdtjWq8Y',
+        start_time: nil,
+        date: DateTime.new(2020, 3, 20, 8, 0, 0, '-07:00'),
+        category: bc,
+        kind: 'youtube_video'
+      },
+      {
+        name: 'March 19, 2020',
+        description: '
+        <strong>Total Cases:</strong> 271 <br>
+        <strong>New Cases:</strong> 40 <br>
+        <strong>Vancouver Coastal Health:</strong> 152 <br>
+        <strong>Fraser Health:</strong> 81 <br>
+        <strong>Vancouver Island:</strong> 22 <br>
+        <strong>Interior Health:</strong> 12 <br>
+        <strong>Northern Health:</strong> 4 <br>
+        ',
+        video_id: 'grnm1mR-6Pk',
+        start_time: nil,
+        date: DateTime.new(2020, 3, 19, 8, 0, 0, '-07:00'),
+        category: bc,
+        kind: 'youtube_video'
+      },
+      {
+        name: 'March 23, 2020',
+        description: '
+        ',
+        video_id: 'g_fNMmWpdlM',
+        start_time: 2521,
+        date: DateTime.new(2020, 3, 23, 8, 0, 0, '-07:00'),
+        category: on,
+        kind: 'youtube_video'
+      },
+      {
+        name: 'March 21, 2020',
+        description: '
+        ',
+        video_id: 'ARBgnsoRQNY',
+        start_time: nil,
+        date: DateTime.new(2020, 3, 21, 8, 0, 0, '-07:00'),
+        category: on,
+        kind: 'youtube_video'
+      },
+      {
+        name: 'March 20, 2020',
+        description: '
+        ',
+        video_id: '10b5fzKqfdM',
+        start_time: nil,
+        date: DateTime.new(2020, 3, 20, 8, 0, 0, '-07:00'),
+        category: on,
+        kind: 'youtube_video'
+      },
+      {
+        name: 'March 19, 2020',
+        description: '
+        ',
+        video_id: 'NdHmGP96ow4',
+        start_time: nil,
+        date: DateTime.new(2020, 3, 19, 8, 0, 0, '-07:00'),
+        category: on,
+        kind: 'youtube_video'
+      }
+    ])
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_24_023911) do
+ActiveRecord::Schema.define(version: 2020_03_24_193209) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,12 +15,12 @@ users = User.create!([
 national = Category.create!(name: 'National', kind: 'daily_update', priority: 1, slug: 'canada')
 ab = Category.create!(name: 'Alberta', kind: 'daily_update', priority: 2, slug: 'alberta')
 bc = Category.create!(name: 'British Columbia', kind: 'daily_update', priority: 3, slug: 'british-columbia')
-on = Category.create!(name: 'Ontario', kind: 'daily_update', priority: 1, slug: 'ontario')
+on = Category.create!(name: 'Ontario', kind: 'daily_update', priority: 4, slug: 'ontario')
 
 about = Category.create!(name: 'About', kind: 'general', priority: 1, slug: 'about')
 spread = Category.create!(name: 'Spread', kind: 'general', priority: 2, slug: 'spread')
 tools = Category.create!(name: 'Tools', kind: 'general', priority: 3, slug: 'tools')
-other = Category.create!(name: 'Other', kind: 'general', priority: 3, slug: 'other')
+other = Category.create!(name: 'Other', kind: 'general', priority: 4, slug: 'other')
 
 ##
 # Resources

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# NOTE, THESE SHOULD _NOT_ BE COMMITTED.
+User.destroy_all
+Category.destroy_all
+
 print 'Seeding db...'
 ##
 # Users

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# NOTE, THESE SHOULD _NOT_ BE COMMITTED.
 User.destroy_all
 Category.destroy_all
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -51,7 +51,8 @@ resources = Resource.create!([
     date: DateTime.new(2020, 3, 21, 8, 0, 0, '-07:00'),
     category: national,
     kind: 'youtube_video'
-  }, {
+  },
+  {
     name: 'March 20, 2020',
     description: 'Canada will turn back asylum-seekers attempting to enter the country outside of official border points, announced Prime Minister Justin Trudeau. It part of a set of extreme new measures meant to stop the spreadv of COVID-19.',
     video_id: 'om2fbGu8giw',
@@ -59,7 +60,156 @@ resources = Resource.create!([
     date: DateTime.new(2020, 3, 20, 8, 0, 0, '-07:00'),
     category: national,
     kind: 'youtube_video'
+  },
+  {
+    name: 'March 23, 2020',
+    description: '<strong>Total Cases:</strong> 301 <br>
+    <strong>New Cases:</strong> 42 <br>',
+    video_id: '5eNZMiFX9Pc',
+    start_time: nil,
+    date: DateTime.new(2020, 3, 23, 8, 0, 0, '-07:00'),
+    category: ab,
+    kind: 'youtube_video'
+  },
+  {
+    name: 'March 21, 2020',
+    description: '<strong>Total Cases:</strong> 226 <br>
+    <strong>New Cases:</strong> 31 <br>',
+    video_id: 'sV5QnlvFfXY',
+    start_time: nil,
+    date: DateTime.new(2020, 3, 21, 8, 0, 0, '-07:00'),
+    category: ab,
+    kind: 'youtube_video'
+  },
+  {
+    name: 'March 20, 2020',
+    description: '<strong>Total Cases:</strong> 195 <br>
+    <strong>New Cases:</strong> 49 <br>',
+    video_id: 's6SkgYaQkOc',
+    start_time: nil,
+    date: DateTime.new(2020, 3, 20, 8, 0, 0, '-07:00'),
+    category: ab,
+    kind: 'youtube_video'
+  },
+  {
+    name: 'March 19, 2020',
+    description: '<strong>Total Cases:</strong> 146 <br>
+    <strong>New Cases:</strong> 27 <br>',
+    video_id: 'alzOXftShR0',
+    start_time: nil,
+    date: DateTime.new(2020, 3, 19, 8, 0, 0, '-07:00'),
+    category: ab,
+    kind: 'youtube_video'
+  },
+  {
+    name: 'March 23, 2020',
+    description: '
+    Note: First 15 seconds has no audio<br><br>
+    <strong>Total Cases:</strong> 472 <br>
+    <strong>New Cases (48 hrs):</strong> 48 <br>
+    <strong>Vancouver Coastal Health:</strong> 248 <br>
+    <strong>Fraser Health:</strong> 150 <br>
+    <strong>Vancouver Island:</strong> 39 <br>
+    <strong>Interior Health:</strong> 30 <br>
+    <strong>Northern Health:</strong> 5 <br>
+    ',
+    video_id: 'tSb19Trz-uQ',
+    start_time: nil,
+    date: DateTime.new(2020, 3, 23, 8, 0, 0, '-07:00'),
+    category: bc,
+    kind: 'youtube_video'
+  },
+  {
+    name: 'March 21, 2020',
+    description: '
+    <strong>Total Cases:</strong> 424 <br>
+    <strong>New Cases:</strong> 74 <br>
+    <strong>Vancouver Coastal Health:</strong> 230 <br>
+    <strong>Fraser Health:</strong> 126 <br>
+    <strong>Vancouver Island:</strong> 37 <br>
+    <strong>Interior Health:</strong> 27 <br>
+    <strong>Northern Health:</strong> 4 <br>
+    ',
+    video_id: 'lJTIFJFFJpw',
+    start_time: nil,
+    date: DateTime.new(2020, 3, 21, 8, 0, 0, '-07:00'),
+    category: bc,
+    kind: 'youtube_video'
+  },
+  {
+    name: 'March 20, 2020',
+    description: '
+    <strong>Total Cases:</strong> 348 <br>
+    <strong>New Cases:</strong> 77 <br>
+    <strong>Vancouver Coastal Health:</strong> 200 <br>
+    <strong>Fraser Health:</strong> 95 <br>
+    <strong>Vancouver Island:</strong> 30 <br>
+    <strong>Interior Health:</strong> 19 <br>
+    <strong>Northern Health:</strong> 4 <br>
+    ',
+    video_id: 'o6eVdtjWq8Y',
+    start_time: nil,
+    date: DateTime.new(2020, 3, 20, 8, 0, 0, '-07:00'),
+    category: bc,
+    kind: 'youtube_video'
+  },
+  {
+    name: 'March 19, 2020',
+    description: '
+    <strong>Total Cases:</strong> 271 <br>
+    <strong>New Cases:</strong> 40 <br>
+    <strong>Vancouver Coastal Health:</strong> 152 <br>
+    <strong>Fraser Health:</strong> 81 <br>
+    <strong>Vancouver Island:</strong> 22 <br>
+    <strong>Interior Health:</strong> 12 <br>
+    <strong>Northern Health:</strong> 4 <br>
+    ',
+    video_id: 'grnm1mR-6Pk',
+    start_time: nil,
+    date: DateTime.new(2020, 3, 19, 8, 0, 0, '-07:00'),
+    category: bc,
+    kind: 'youtube_video'
+  },
+  {
+    name: 'March 23, 2020',
+    description: '
+    ',
+    video_id: 'g_fNMmWpdlM',
+    start_time: 2521,
+    date: DateTime.new(2020, 3, 23, 8, 0, 0, '-07:00'),
+    category: on,
+    kind: 'youtube_video'
+  },
+  {
+    name: 'March 21, 2020',
+    description: '
+    ',
+    video_id: 'ARBgnsoRQNY',
+    start_time: nil,
+    date: DateTime.new(2020, 3, 21, 8, 0, 0, '-07:00'),
+    category: on,
+    kind: 'youtube_video'
+  },
+  {
+    name: 'March 20, 2020',
+    description: '
+    ',
+    video_id: '10b5fzKqfdM',
+    start_time: nil,
+    date: DateTime.new(2020, 3, 20, 8, 0, 0, '-07:00'),
+    category: on,
+    kind: 'youtube_video'
+  },
+  {
+    name: 'March 19, 2020',
+    description: '
+    ',
+    video_id: 'NdHmGP96ow4',
+    start_time: nil,
+    date: DateTime.new(2020, 3, 19, 8, 0, 0, '-07:00'),
+    category: on,
+    kind: 'youtube_video'
   }
-  ])
+])
 
 print 'done'


### PR DESCRIPTION
Fixes #11 

This PR refactors the Home view a bit, and loads the daily_update resources (and categories) from the DB. I added all the current resources to the seeds, so it should be possible to just run `rake db:seed` once this is merged.