### PR TITLE
Use ActionText for "rich descriptions" of resources

### DIFF
--- a/app/assets/stylesheets/actiontext.scss
+++ b/app/assets/stylesheets/actiontext.scss
@@ -1,0 +1,36 @@
+//
+// Provides a drop-in pointer for the default Trix stylesheet that will format the toolbar and
+// the trix-editor content (whether displayed or under editing). Feel free to incorporate this
+// inclusion directly in any other asset bundle and remove this file.
+//
+//= require trix/dist/trix
+
+// We need to override trix.css’s image gallery styles to accommodate the
+// <action-text-attachment> element we wrap around attachments. Otherwise,
+// images in galleries will be squished by the max-width: 33%; rule.
+.trix-content {
+  .attachment-gallery {
+    > action-text-attachment,
+    > .attachment {
+      flex: 1 0 33%;
+      padding: 0 0.5em;
+      max-width: 33%;
+    }
+
+    &.attachment-gallery--2,
+    &.attachment-gallery--4 {
+      > action-text-attachment,
+      > .attachment {
+        flex-basis: 50%;
+        max-width: 50%;
+      }
+    }
+  }
+
+  action-text-attachment {
+    .attachment {
+      padding: 0 !important;
+      max-width: 100% !important;
+    }
+  }
+}

--- a/app/controllers/admin/resources_controller.rb
+++ b/app/controllers/admin/resources_controller.rb
@@ -33,7 +33,7 @@ class Admin::ResourcesController < Admin::BaseController
   def update
     respond_to do |format|
       if @resource.update(resource_params)
-        format.html { redirect_to [:admin, @category], notice: "Resource was successfully updated." }
+        format.html { redirect_to [:admin, @resource], notice: "Resource was successfully updated." }
         format.json { render :show, status: :ok, location: @resource }
       else
         format.html { render :edit }
@@ -56,7 +56,7 @@ private
   end
 
     def resource_params
-      params.require(:resource).permit(:name, :url, :kind, :priority, :category_id, :user_id, :date, :description, :video_id, :start_time)
+      params.require(:resource).permit(:name, :url, :kind, :priority, :category_id, :user_id, :date, :description, :video_id, :start_time, :content)
     end
 
 end

--- a/app/controllers/admin/resources_controller.rb
+++ b/app/controllers/admin/resources_controller.rb
@@ -56,7 +56,7 @@ private
   end
 
     def resource_params
-      params.require(:resource).permit(:name, :url, :kind, :priority, :category_id, :user_id, :date, :description, :video_id, :start_time, :content)
+      params.require(:resource).permit(:name, :url, :kind, :priority, :category_id, :user_id, :date, :description, :video_id, :start_time, :rich_description)
     end
 
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -24,3 +24,6 @@ require("jquery")
 import './bootstrap.bundle.js'
 
 
+
+require("trix")
+require("@rails/actiontext")

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -2,7 +2,8 @@ class Resource < ApplicationRecord
 
   belongs_to :category
   belongs_to :user, optional: true
-
+  has_rich_text :content
+  
   scope :by_date, -> { order(date: :desc) }
 
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -2,8 +2,8 @@ class Resource < ApplicationRecord
 
   belongs_to :category
   belongs_to :user, optional: true
-  has_rich_text :content
-  
+  has_rich_text :rich_description
+
   scope :by_date, -> { order(date: :desc) }
 
 end

--- a/app/views/admin/resources/_form.html.erb
+++ b/app/views/admin/resources/_form.html.erb
@@ -3,7 +3,7 @@
     <div class="col-md-8">
       <div class="card login-card">
         <div class="card-header text-white bg-secondary">
-          <h3>New Resource</h3>
+          <h3><%= title %></h3>
         </div>
         <div class="card-body text-white bg-dark">
           <%= form_for [:admin, @resource] do |form| %>
@@ -31,7 +31,7 @@
             <% end %>
 
             <div class="form-group row">
-              <%= form.label :start_time, class: "col-md-4 col-form-label text-md-right" %>
+              <%= form.label :start_time, "Start Time (sec)", class: "col-md-4 col-form-label text-md-right" %>
               <div class="col-md-6">
                 <%= form.number_field :start_time %>
               </div>
@@ -59,23 +59,20 @@
             </div>
 
             <div class="form-group row mb-4">
-              <%= form.label :rich_description, class: "col-md-4 col-form-label text-md-right" %>
+              <%= form.label :rich_description, "Description", class: "col-md-4 col-form-label text-md-right" %>
               <div class="col-md-12">
                 <%= form.rich_text_area :rich_description %>
               </div>
             </div>
 
             <div class="form-group row mb-0">
-              <div class="col-md-8 offset-md-4">
+              <div class="col-md-8">
                 <div class="actions">
-                  <%= form.submit "Create Resource", class: "btn btn-primary mb-3"%>
+                  <%= form.submit nil, class: "btn btn-success mb-3"%>
+                  <%= link_to 'Back', admin_resources_path,  class: "btn btn-light mb-3" %>
                 </div>
               </div>
-              <div class="col-md-8 offset-md-2">
-                <h5><%= link_to 'Back', admin_resources_path %></h5>
-              </div>
             </div>
-            
           <% end %>
         </div>
       </div>

--- a/app/views/admin/resources/_form.html.erb
+++ b/app/views/admin/resources/_form.html.erb
@@ -59,9 +59,9 @@
             </div>
 
             <div class="form-group row mb-4">
-              <%= form.label :content, class: "col-md-4 col-form-label text-md-right" %>
+              <%= form.label :rich_description, class: "col-md-4 col-form-label text-md-right" %>
               <div class="col-md-12">
-                <%= form.rich_text_area :content %>
+                <%= form.rich_text_area :rich_description %>
               </div>
             </div>
 

--- a/app/views/admin/resources/_form.html.erb
+++ b/app/views/admin/resources/_form.html.erb
@@ -58,6 +58,13 @@
               </div>
             </div>
 
+            <div class="form-group row mb-4">
+              <%= form.label :content, class: "col-md-4 col-form-label text-md-right" %>
+              <div class="col-md-12">
+                <%= form.rich_text_area :content %>
+              </div>
+            </div>
+
             <div class="form-group row mb-0">
               <div class="col-md-8 offset-md-4">
                 <div class="actions">

--- a/app/views/admin/resources/_form.html.erb
+++ b/app/views/admin/resources/_form.html.erb
@@ -21,7 +21,7 @@
 
             <%= form.text_field :user_id, type: "hidden", value: current_user.id %>
 
-            <% [:name, :url, :kind, :description, :video_id].each do |column| %>
+            <% [:name, :url, :kind, :video_id].each do |column| %>
               <div class="form-group row">
                 <%= form.label column, class: "col-md-4 col-form-label text-md-right" %>
                 <div class="col-md-6">

--- a/app/views/admin/resources/edit.html.erb
+++ b/app/views/admin/resources/edit.html.erb
@@ -1,6 +1,2 @@
-<h1>Editing Resource</h1>
 
-<%= render 'form', resource: @resource %>
-
-<%= link_to 'Show', admin_resource_path(@resource) %> |
-<%= link_to 'Back', admin_resources_path %>
+<%= render 'form', resource: @resource, title: "Edit Resource", action: 'edit' %>

--- a/app/views/admin/resources/new.html.erb
+++ b/app/views/admin/resources/new.html.erb
@@ -1,3 +1,1 @@
-<%= render 'form', resource: @resource %>
-
-
+<%= render 'form', resource: @resource, title: "New Resource" %>

--- a/app/views/admin/resources/show.html.erb
+++ b/app/views/admin/resources/show.html.erb
@@ -54,7 +54,7 @@
 
 <p>
   <strong>Content</strong>
-  <%= @resource.content %>
+  <%= @resource.rich_description %>
 </p>
 
 <%= link_to 'Edit', edit_admin_resource_path(@resource) %> |

--- a/app/views/admin/resources/show.html.erb
+++ b/app/views/admin/resources/show.html.erb
@@ -52,5 +52,10 @@
   <%= @resource.start_time %>
 </p>
 
+<p>
+  <strong>Content</strong>
+  <%= @resource.content %>
+</p>
+
 <%= link_to 'Edit', edit_admin_resource_path(@resource) %> |
 <%= link_to 'Back', admin_resources_path %>

--- a/app/views/admin/resources/show.html.erb
+++ b/app/views/admin/resources/show.html.erb
@@ -36,13 +36,6 @@
 </p>
 
 <p>
-  <strong>Description:</strong>
-  <hr>
-  <%= sanitize @resource.description %>
-  <hr>
-</p>
-
-<p>
   <strong>Video ID:</strong>
   <%= @resource.video_id %>
 </p>

--- a/app/views/pages/_resource-card.html.erb
+++ b/app/views/pages/_resource-card.html.erb
@@ -7,7 +7,9 @@
 
     <div class="card-body">
     <h4 class="card-title"><%= resource.name %></h4>
-    <p class="card-text"><%= sanitize resource.description %></p>
+    <div class="card-text">
+      <%= resource.rich_description %>
+    </div>
     </div>
     <div class="card-footer">
     <a href="https://youtu.be/<%= resource.video_id %>?t=<%= resource.start_time %>" class="btn btn-primary" target='_blank'>Watch</a>

--- a/db/migrate/20200324221347_create_action_text_tables.action_text.rb
+++ b/db/migrate/20200324221347_create_action_text_tables.action_text.rb
@@ -1,0 +1,14 @@
+# This migration comes from action_text (originally 20180528164100)
+class CreateActionTextTables < ActiveRecord::Migration[6.0]
+  def change
+    create_table :action_text_rich_texts do |t|
+      t.string     :name, null: false
+      t.text       :body, size: :long
+      t.references :record, null: false, polymorphic: true, index: false
+
+      t.timestamps
+
+      t.index [ :record_type, :record_id, :name ], name: "index_action_text_rich_texts_uniqueness", unique: true
+    end
+  end
+end

--- a/db/migrate/20200324222620_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20200324222620_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/migrate/20200324225653_convert_descriptions_to_action_text.rb
+++ b/db/migrate/20200324225653_convert_descriptions_to_action_text.rb
@@ -1,0 +1,8 @@
+class ConvertDescriptionsToActionText < ActiveRecord::Migration[6.0]
+  def change
+    Resource.all.each do |resource|
+      resource.rich_description = resource.description
+      resource.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,41 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_24_193209) do
+ActiveRecord::Schema.define(version: 2020_03_24_222620) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "action_text_rich_texts", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "body"
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
+  end
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "categories", force: :cascade do |t|
     t.string "name"
@@ -53,6 +84,7 @@ ActiveRecord::Schema.define(version: 2020_03_24_193209) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "resources", "categories"
   add_foreign_key "resources", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_24_222620) do
+ActiveRecord::Schema.define(version: 2020_03_24_225653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "private": true,
   "dependencies": {
     "@rails/actioncable": "^6.0.0",
+    "@rails/actiontext": "^6.0.2-2",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.2.2",
     "jquery": "^3.4.1",
+    "trix": "^1.0.0",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",

--- a/test/fixtures/action_text/rich_texts.yml
+++ b/test/fixtures/action_text/rich_texts.yml
@@ -1,0 +1,4 @@
+# one:
+#   record: name_of_fixture (ClassOfFixture)
+#   name: content
+#   body: <p>In a <i>million</i> stars!</p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -792,7 +792,14 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-6.0.2.tgz#bcba9bcd6ee09a47c6628336e07399a68ca87814"
   integrity sha512-vN78gohsXPlC5jxBHlmiwkUI9bv6SulcZaE72kAIg/G4ou+wTdiMWPJK1bf2IxUNf+sfOjhl+tbRmY4AzJcgrw==
 
-"@rails/activestorage@^6.0.0":
+"@rails/actiontext@^6.0.2-2":
+  version "6.0.2-2"
+  resolved "https://registry.yarnpkg.com/@rails/actiontext/-/actiontext-6.0.2-2.tgz#57482adbbfaab65520b5433e7e44d63b7784c739"
+  integrity sha512-qPD6tN2QiJ+zuzpr15AiY0VXScFiRcDJRP1zzxXT3L5fTuMpToA6Bq1JFJm9ckLKZZxqWUilff1stqM51QABVQ==
+  dependencies:
+    "@rails/activestorage" "^6.0.0-alpha"
+
+"@rails/activestorage@^6.0.0", "@rails/activestorage@^6.0.0-alpha":
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@rails/activestorage/-/activestorage-6.0.2.tgz#3882da2716d1f21091840fc52b71091d406a9c43"
   integrity sha512-X0uGBLNsSKvVw5n93rH7k+7rbxc3Cq7p0ShiQbrk1cN0xflGjElzEJRY3okZZHsKkCV+h6rFCk0BOBVrLSrJ0A==
@@ -6953,6 +6960,11 @@ trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
   integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
+
+trix@^1.0.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/trix/-/trix-1.2.3.tgz#354d8002b3b8f7af426a85097c2fa2042a538d2b"
+  integrity sha512-1E/abahXhFgrTsIfd20c2NRp3VXqtwzseFevfZdHjvqS2+7TDfGGefn2BAeHnsInR3QWoLn33xAXw6aGZVVRgw==
 
 "true-case-path@^1.0.2":
   version "1.0.3"


### PR DESCRIPTION
Fixes #14 

I kept the "description" column for the moment since the migration that I wrote needs it to populate the "rich_description" for each resource. To deploy this, all that should be necessary is to run the migrations. We could make a new issue/PR for removing the description column and renaming "rich_description" to "description".

I opted to keep local storage for Active Storage, which is needed by Action Text, instead of setting up S3 or something similar. All this means is that embedding images won't work, because Heroku will periodically purge local storage. I don't think this is an issue for now?