### PR TITLE
Feature admin resource filtering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'jbuilder', '~> 2.7'
 
 gem 'devise'
 gem 'kaminari'
+gem 'filterrific'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
     diff-lcs (1.3)
     erubi (1.9.0)
     ffi (1.12.2)
+    filterrific (5.2.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.8.2)
@@ -244,6 +245,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   devise
+  filterrific
   jbuilder (~> 2.7)
   kaminari
   listen (>= 3.0.5, < 3.2)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
+//= link filterrific/filterrific-spinner.gif

--- a/app/assets/stylesheets/categories.scss
+++ b/app/assets/stylesheets/categories.scss
@@ -2,21 +2,20 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
-// select {
-//   margin-top: 11px;
-//   position: relative;
-//   align-items: flex-end;
-//   display: inline-block;
-//   cursor: pointer;
-//   text-align: center;
-//   text-decoration: none;
-//   font-family: Arial, Helvetica, sans-serif;
-//   border-radius: 3px;
-//   border: none;
-//   background: #f1f1f1;
-//   padding: 2px;
-// }
+select {
+  height: 40px;
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+  text-align: center;
+  text-decoration: none;
+  font-family: Arial, Helvetica, sans-serif;
+  border-radius: 3px;
+  border: none;
+  background: #f1f1f1;
+  padding: 2px;
+}
     
-// select:hover {
-//   background-color: dodgerblue;
-// }
+select:hover {
+  background-color: dodgerblue;
+}

--- a/app/assets/stylesheets/categories.scss
+++ b/app/assets/stylesheets/categories.scss
@@ -2,21 +2,21 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
-select {
-  margin-top: 11px;
-  position: relative;
-  align-items: flex-end;
-  display: inline-block;
-  cursor: pointer;
-  text-align: center;
-  text-decoration: none;
-  font-family: Arial, Helvetica, sans-serif;
-  border-radius: 3px;
-  border: none;
-  background: #f1f1f1;
-  padding: 2px;
-}
+// select {
+//   margin-top: 11px;
+//   position: relative;
+//   align-items: flex-end;
+//   display: inline-block;
+//   cursor: pointer;
+//   text-align: center;
+//   text-decoration: none;
+//   font-family: Arial, Helvetica, sans-serif;
+//   border-radius: 3px;
+//   border: none;
+//   background: #f1f1f1;
+//   padding: 2px;
+// }
     
-select:hover {
-  background-color: dodgerblue;
-}
+// select:hover {
+//   background-color: dodgerblue;
+// }

--- a/app/assets/stylesheets/resources.scss
+++ b/app/assets/stylesheets/resources.scss
@@ -3,7 +3,6 @@
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
 select {
-  // margin-top: 11px;
   height: 40px;
   position: relative;
   display: inline-block;

--- a/app/assets/stylesheets/resources.scss
+++ b/app/assets/stylesheets/resources.scss
@@ -3,9 +3,9 @@
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
 select {
-  margin-top: 11px;
+  // margin-top: 11px;
+  height: 40px;
   position: relative;
-  align-items: flex-end;
   display: inline-block;
   cursor: pointer;
   text-align: center;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -24,6 +24,9 @@ require("jquery")
 import './bootstrap.bundle.js'
 
 
+//= require filterrific/filterrific-jquery
+
+
 
 require("trix")
 require("@rails/actiontext")

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -2,4 +2,8 @@ class Category < ApplicationRecord
 
   has_many :resources, dependent: :nullify
 
+  def self.options_for_select
+    order("LOWER(name)").map { |category| [category.name, category.id] }
+  end
+
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -6,6 +6,75 @@ class Resource < ApplicationRecord
 
   scope :by_date, -> { order(date: :desc) }
 
+  filterrific(
+    default_filter_params: { sorted_by: 'created_at_desc' },
+    available_filters: [ :sorted_by, :search_query, :with_category_id, :with_resources_since ]
+  )
+
+  scope :search_query, ->(query) {
+    return nil  if query.blank?
+
+    # condition query, parse into individual keywords
+    terms = query.downcase.split(/\s+/)
+  
+    # replace "*" with "%" for wildcard searches,
+    # append '%', remove duplicate '%'s
+    terms = terms.map { |e|
+      (e.tr("*", "%") + "%").gsub(/%+/, "%")
+    }
+    # configure number of OR conditions for provision
+    # of interpolation arguments. Adjust this if you
+    # change the number of OR conditions.
+    num_or_conds = 2
+
+    where(
+      terms.map { |_term|
+        # feel free to append more LIKE queries, but remember to increase num_or_condsas well
+        "(LOWER(resources.name) LIKE ? OR LOWER(resources.kind) LIKE ?)"
+        }.join(" AND "),
+        *terms.map { |e| [e] * num_or_conds }.flatten,
+      )
+    }
+    # LOWER(categories.name) LIKE ?
+  
+
+  scope :sorted_by, ->(sort_option) {
+
+    # simple regex match to extract sort direction 
+    direction = /desc$/.match?(sort_option) ? "desc" : "asc"
+
+    case sort_option.to_s
+
+    when /^created_at_/
+      order("resources.created_at #{direction}")
+    when /^name_/
+      # Simple sort on the name columns
+      order("LOWER(resources.name) #{direction}")
+    when /^category_id_/
+      # grab and sort all resources with a category
+      order("LOWER(categories.name) #{direction}").includes(:category).references(:category)
+    else
+      raise(ArgumentError, "Invalid sort option: #{sort_option.inspect}")
+    end
+  }
+
+  scope :with_category_id, ->(category_id) {
+    where("categories.id = ?", category_id).joins(:category)
+  }
+
+  scope :with_resources_since, ->(reference_date) {
+    where("resources.created_at >= ?", reference_date)
+  }
+
+  def self.options_for_sorted_by
+    [
+      ["Name (a-z)", "name_asc"],
+      ["Date (newest first)", "created_at_desc"],
+      ["Date (oldest first)", "created_at_asc"],
+      ["Category (a-z)", "category_id_asc"],
+    ]
+  end
+
   paginates_per 50
 
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -29,14 +29,12 @@ class Resource < ApplicationRecord
 
     where(
       terms.map { |_term|
-        # feel free to append more LIKE queries, but remember to increase num_or_condsas well
+        # feel free to append more LIKE queries, but remember to increase num_or_conds as well
         "(LOWER(resources.name) LIKE ? OR LOWER(resources.kind) LIKE ?)"
         }.join(" AND "),
         *terms.map { |e| [e] * num_or_conds }.flatten,
       )
-    }
-    # LOWER(categories.name) LIKE ?
-  
+    }  
 
   scope :sorted_by, ->(sort_option) {
 

--- a/app/views/admin/resources/_list.html.erb
+++ b/app/views/admin/resources/_list.html.erb
@@ -1,6 +1,7 @@
 <div class="container">
-  <div class="col-md-12">
+  <div class="ml-2">
     <div id="filterrific_results">
+
       <table class="table">
         <thead>
           <tr>
@@ -9,26 +10,26 @@
             <th scope="col">Url</th>
             <th scope="col">Kind</th>
             <th scope="col">Priority</th>
-
             <th colspan="3"></th>
-
           </tr>
         </thead>
+
         <tbody>
           <% @resources.each do |resource| %>
             <tr>
               <td><%= resource.category.name %></td>
               <td><%= resource.name %></td>
-              <td><%= link_to('link', resource.url, target: '_blank') if resource.url.present? %></td>
+              <td><%= link_to('Link', resource.url, target: '_blank') if resource.url.present? %></td>
               <td><%= resource.kind %></td>
               <td><%= resource.priority %></td>
-              <td><%= link_to 'Show', admin_resource_path(resource) %></td>
-              <td><%= link_to 'Edit', edit_admin_resource_path(resource) %></td>
-              <td><%= link_to 'Destroy', admin_resource_path(resource), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+              <td><%= link_to 'Show', admin_resource_path(resource), class: 'btn-sm btn-primary' %></td>
+              <td><%= link_to 'Edit', edit_admin_resource_path(resource), class: 'btn-sm btn-secondary' %></td>
+              <td><%= link_to 'Destroy', admin_resource_path(resource), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn-sm btn-danger' %></td>
             </tr>
           <% end %>
         </tbody>
       </table>
+
     </div>
 
     <%= paginate @resources %>

--- a/app/views/admin/resources/_list.html.erb
+++ b/app/views/admin/resources/_list.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container mt-2">
   <div class="ml-2">
     <div id="filterrific_results">
 

--- a/app/views/admin/resources/_list.html.erb
+++ b/app/views/admin/resources/_list.html.erb
@@ -1,0 +1,39 @@
+<div class="container">
+  <div class="col-md-12">
+    <div id="filterrific_results">
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col">Category</th>
+            <th scope="col">Name</th>
+            <th scope="col">Url</th>
+            <th scope="col">Kind</th>
+            <th scope="col">Priority</th>
+
+            <th colspan="3"></th>
+
+          </tr>
+        </thead>
+        <tbody>
+          <% @resources.each do |resource| %>
+            <tr>
+              <td><%= resource.category.name %></td>
+              <td><%= resource.name %></td>
+              <td><%= link_to('link', resource.url, target: '_blank') if resource.url.present? %></td>
+              <td><%= resource.kind %></td>
+              <td><%= resource.priority %></td>
+              <td><%= link_to 'Show', admin_resource_path(resource) %></td>
+              <td><%= link_to 'Edit', edit_admin_resource_path(resource) %></td>
+              <td><%= link_to 'Destroy', admin_resource_path(resource), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <%= paginate @resources %>
+
+    <%= link_to 'New Resource', new_admin_resource_path, class: 'btn btn-primary' %>
+  </div>
+
+</div>

--- a/app/views/admin/resources/_list.html.erb
+++ b/app/views/admin/resources/_list.html.erb
@@ -17,7 +17,7 @@
         <tbody>
           <% @resources.each do |resource| %>
             <tr>
-              <td><%= resource.category.name %></td>
+              <td><%= resource.category ? resource.category.name : 'Uncategorized' %></td>
               <td><%= resource.name %></td>
               <td><%= link_to('Link', resource.url, target: '_blank') if resource.url.present? %></td>
               <td><%= resource.kind %></td>

--- a/app/views/admin/resources/index.html.erb
+++ b/app/views/admin/resources/index.html.erb
@@ -2,44 +2,56 @@
 <title>Admin - Resources || covid-upates.ca</title>
 <% end %>
 
+<p id="notice"><%= notice %></p>
 <div class="container">
-  <div class="col-md-12">
-    <p id="notice"><%= notice %></p>
+  <div class="col-md-6">
     <h1>Resources</h1>
-
-    <table class="table">
-      <thead>
-        <tr>
-          <th scope="col">Category</th>
-          <th scope="col">Name</th>
-          <th scope="col">Url</th>
-          <th scope="col">Kind</th>
-          <th scope="col">Priority</th>
-
-          <th colspan="3"></th>
-
-        </tr>
-      </thead>
-      <tbody>
-        <% @resources.each do |resource| %>
-          <tr>
-            <td><%= resource.category.name %></td>
-            <td><%= resource.name %></td>
-            <td><%= link_to('link', resource.url, target: '_blank') if resource.url.present? %></td>
-            <td><%= resource.kind %></td>
-            <td><%= resource.priority %></td>
-            <td><%= link_to 'Show', admin_resource_path(resource) %></td>
-            <td><%= link_to 'Edit', edit_admin_resource_path(resource) %></td>
-            <td><%= link_to 'Destroy', admin_resource_path(resource), method: :delete, data: { confirm: 'Are you sure?' } %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-
-    <%= paginate @resources %>
-
-    <%= link_to 'New Resource', new_admin_resource_path, class: 'btn btn-primary' %>
   </div>
-
 </div>
 
+  <%= form_for_filterrific @filterrific do |f| %>
+    <div class="container d-flex flex-column">
+      <div class="d-flex flex-row-reverse mb-2">
+        <%= link_to('Reset Filters', reset_filterrific_url, class: "btn btn-primary ml-3 align-bottom") %>
+      </div>
+      <main class="card card-body bg-light d-flex flex-row h-25 mx-auto">
+        <div class="col-md-3">
+          <div class="form-group">
+            <label class="font-weight-bold">Search:</label>
+            <%= f.text_field(
+              :search_query,
+              class: 'filterrific-periodically-observed form-control'
+            ) %>
+          </div>
+        </div>
+        <div class="col-md-3">
+          <div class="form-group">
+            <label class="font-weight-bold">Category:</label>
+            <%= f.select(
+              :with_category_id,
+              @filterrific.select_options[:with_category_id],
+              { include_blank: '- Any -' }
+            ) %>
+          </div>
+        </div>
+        <div class="col-md-3">
+          <div class="form-group">
+            <label class="font-weight-bold">Submitted After:</label>
+            <%= f.date_field :with_resources_since, class: 'js-datepicker form-control' %>
+          </div>
+        </div>
+        <div class="col-md-3">
+          <div class="form-group">
+            <label class="font-weight-bold">Sorted By:</label>
+            <%= f.select :sorted_by, @filterrific.select_options[:sorted_by], class: 'form-control' %>
+          </div>
+        </div>
+        
+        <%= render_filterrific_spinner %>
+
+      </main>
+  </div>
+  <% end %>
+
+
+<%= render 'list', resources: @resources %>

--- a/app/views/admin/resources/index.html.erb
+++ b/app/views/admin/resources/index.html.erb
@@ -10,10 +10,10 @@
 </div>
 
   <%= form_for_filterrific @filterrific do |f| %>
-    <div class="container d-flex flex-column mb-4">
+    <div class="container d-flex flex-column">
     
       <div class="d-flex flex-row-reverse">
-        <%= link_to('Reset Filters', reset_filterrific_url, class: "btn btn-info mb-3 align-bottom") %>
+        <%= link_to('Reset Filters', reset_filterrific_url, class: "btn btn-info mb-2 align-bottom") %>
       </div>
 
       <main class="card card-body bg-light d-flex flex-row h-25 mx-auto">
@@ -57,6 +57,9 @@
       
     </div>
   <% end %>
+  <div class="w-25 col-md-6 mt-3 mb-3 ml-5">
+    <h6><%= @resources.count %> results</h6>
+  </div>
 
 
 <%= render 'list', resources: @resources %>

--- a/app/views/admin/resources/index.html.erb
+++ b/app/views/admin/resources/index.html.erb
@@ -10,10 +10,12 @@
 </div>
 
   <%= form_for_filterrific @filterrific do |f| %>
-    <div class="container d-flex flex-column">
-      <div class="d-flex flex-row-reverse mb-2">
-        <%= link_to('Reset Filters', reset_filterrific_url, class: "btn btn-primary ml-3 align-bottom") %>
+    <div class="container d-flex flex-column mb-4">
+    
+      <div class="d-flex flex-row-reverse">
+        <%= link_to('Reset Filters', reset_filterrific_url, class: "btn btn-info mb-3 align-bottom") %>
       </div>
+
       <main class="card card-body bg-light d-flex flex-row h-25 mx-auto">
         <div class="col-md-3">
           <div class="form-group">
@@ -24,6 +26,7 @@
             ) %>
           </div>
         </div>
+
         <div class="col-md-3">
           <div class="form-group">
             <label class="font-weight-bold">Category:</label>
@@ -34,23 +37,25 @@
             ) %>
           </div>
         </div>
+
         <div class="col-md-3">
           <div class="form-group">
             <label class="font-weight-bold">Submitted After:</label>
             <%= f.date_field :with_resources_since, class: 'js-datepicker form-control' %>
           </div>
         </div>
+
         <div class="col-md-3">
           <div class="form-group">
             <label class="font-weight-bold">Sorted By:</label>
             <%= f.select :sorted_by, @filterrific.select_options[:sorted_by], class: 'form-control' %>
           </div>
         </div>
-        
-        <%= render_filterrific_spinner %>
 
+        <%= render_filterrific_spinner %>
       </main>
-  </div>
+      
+    </div>
   <% end %>
 
 

--- a/app/views/admin/resources/index.js.erb
+++ b/app/views/admin/resources/index.js.erb
@@ -1,0 +1,4 @@
+<% js = escape_javascript(
+  render(partial: 'list', locals: { resources: @resources })
+) %>
+$("#filterrific_results").html("<%= js %>");


### PR DESCRIPTION
Admin resources pages now has a fully functional filter station (via Filterrific) at the top that can execute filters based on:

- Search queries
- Category name
- Resources since a selected date
- Sort by dropdown

It is also very quick to implement additional filter scopes.

However, I beat my head against the wall far too long trying to get the live updating working. As of right now all the filter options are working effectively, you just need to hit enter in the search query box to get the results.

I'm sure the live update's a quick easy fix -- just need another perspective (read thru the Filterrific guide to catch what I missed).

Also added some basic styling to put everyone's mind at ease for the time being.

Read through the commits and critique accordingly :)

Resolves #31 
(this will auto close the issue when merged)